### PR TITLE
typo(pyproject): constraint uv version

### DIFF
--- a/docs/SFT_DATA_PREPARATION.md
+++ b/docs/SFT_DATA_PREPARATION.md
@@ -19,15 +19,13 @@
 最小结构示意（字段名仅作结构参考，不包含具体内容）：
 
 ```json
-[
-  {
-    "conversations": [
-      {"role": "user", "content": "..."},
-      {"role": "assistant", "content": "..."}
-    ],
-    "images": null
-  }
-]
+{
+  "conversations": [
+    {"role": "user", "content": "..."},
+    {"role": "assistant", "content": "..."}
+  ],
+  "images": null
+}
 ```
 
 更详细的 item 结构示意（字段名仅作结构参考，不包含具体内容）：

--- a/docs/SFT_DATA_PREPARATION.md
+++ b/docs/SFT_DATA_PREPARATION.md
@@ -107,8 +107,10 @@ class MyDatasetsConfig(CompliableDatasetsConfig):
 
 说明：
 - `domains`：按域组织文件列表（每个文件是 `DataSourceFile`）。
-- `epochs`：采样策略（按域设置 epoch 权重）。
 - `subsample_rate` 范围为 (0, 1]，用于下采样。
+- `epochs`：采样策略（按域设置 epoch 权重），和 `Megatron-LM`参数语义保持一致。
+
+  > 例如 `general` 有 1000 条数据；`math` 有 500 条数据，编译后生成的数据集共 `1000*2+500*1` 条。
 
 ## 3) （可选）编译 datasets
 

--- a/docs/SFT_DATA_PREPARATION.md
+++ b/docs/SFT_DATA_PREPARATION.md
@@ -110,7 +110,7 @@ class MyDatasetsConfig(CompliableDatasetsConfig):
 - `subsample_rate` 范围为 (0, 1]，用于下采样。
 - `epochs`：采样策略（按域设置 epoch 权重），和 `Megatron-LM`参数语义保持一致。
 
-  > 例如 `general` 有 1000 条数据；`math` 有 500 条数据，编译后生成的数据集共 `1000*2+500*1` 条。
+  > 例如 `general` 有 1000 条数据，`subsample_rate=0.3,epoch=2`；`math` 有 500 条数据，DatasetsConfig 共 `1000*0.3+500` 条，随后在 dataloader 进行加权采样，最终生成 `1000*0.3*2+500*1`条数据。
 
 ## 3) （可选）编译 datasets
 

--- a/docs/SFT_DATA_PREPARATION_EN.md
+++ b/docs/SFT_DATA_PREPARATION_EN.md
@@ -107,8 +107,10 @@ class MyDatasetsConfig(CompliableDatasetsConfig):
 
 Notes:
 - `domains`: per-domain file lists (each file is a `DataSourceFile`).
-- `epochs`: sampling plan (epoch weight per domain).
 - `subsample_rate` must be in (0, 1] for downsampling.
+- `epochs`: sampling plan (epoch weight per domain), consistent with Megatron-LM parameter semantics.
+
+  > For example, if `general` has 1000 samples (epoch weight=2) and `math` has 500 samples (epoch weight=1), the compiled dataset will contain 1000\*2+500\*1 samples in total.
 
 ## 3) (Optional) Compile Datasets
 

--- a/docs/SFT_DATA_PREPARATION_EN.md
+++ b/docs/SFT_DATA_PREPARATION_EN.md
@@ -19,15 +19,13 @@ This document explains how to organize SFT data and use it for training. Referen
 Minimal structure (field names are for schema reference only; no real content):
 
 ```json
-[
-  {
-    "conversations": [
-      {"role": "user", "content": "..."},
-      {"role": "assistant", "content": "..."}
-    ],
-    "images": null
-  }
-]
+{
+  "conversations": [
+    {"role": "user", "content": "..."},
+    {"role": "assistant", "content": "..."}
+  ],
+  "images": null
+}
 ```
 
 More detailed item structure (field names are for schema reference only; no real content):

--- a/docs/SFT_DATA_PREPARATION_EN.md
+++ b/docs/SFT_DATA_PREPARATION_EN.md
@@ -110,7 +110,7 @@ Notes:
 - `subsample_rate` must be in (0, 1] for downsampling.
 - `epochs`: sampling plan (epoch weight per domain), consistent with Megatron-LM parameter semantics.
 
-  > For example, `general` has 1000 samples with subsample_rate=0.3, epochs=2; `math` has 500 samples with default settings. The `DatasetsConfig` contains `1000*0.3+500` entries, which are then weighted-sampled in the dataloader, ultimately producing `1000*0.3*2+500*1` samples.。
+  > For example, `general` has 1000 samples with subsample_rate=0.3, epochs=2; `math` has 500 samples with default settings. The `DatasetsConfig` contains `1000*0.3+500` entries, which are then weighted-sampled in the dataloader, ultimately producing `1000*0.3*2+500*1` samples.
 
 ## 3) (Optional) Compile Datasets
 

--- a/docs/SFT_DATA_PREPARATION_EN.md
+++ b/docs/SFT_DATA_PREPARATION_EN.md
@@ -110,7 +110,7 @@ Notes:
 - `subsample_rate` must be in (0, 1] for downsampling.
 - `epochs`: sampling plan (epoch weight per domain), consistent with Megatron-LM parameter semantics.
 
-  > For example, if `general` has 1000 samples (epoch weight=2) and `math` has 500 samples (epoch weight=1), the compiled dataset will contain 1000\*2+500\*1 samples in total.
+  > For example, `general` has 1000 samples with subsample_rate=0.3, epochs=2; `math` has 500 samples with default settings. The `DatasetsConfig` contains `1000*0.3+500` entries, which are then weighted-sampled in the dataloader, ultimately producing `1000*0.3*2+500*1` samples.。
 
 ## 3) (Optional) Compile Datasets
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,8 @@ dependencies = [
     "asciichartpy>=1.5.25",
 ]
 
-
+[tool.uv]
+required-version = ">=0.8.4"
 
 [tool.uv.sources]
 nv-grouped-gemm = { git = "https://github.com/fanshiqing/grouped_gemm.git" }

--- a/steptronoss/data/datasets/stepchat_dataset.py
+++ b/steptronoss/data/datasets/stepchat_dataset.py
@@ -114,7 +114,7 @@ class StepChatJsonDataset(torch.utils.data.Dataset):
             origin_len = 0
 
             with smart_open(f_path, "rb") as f:
-                for _ in ijson.items(f, "item", use_float=True):
+                for _ in ijson.items(f, "conversations", use_float=True):
                     origin_len += 1
             raw_indices = random.Random(1234).sample(range(origin_len), int(origin_len * sample_rate))
             raw_indices = {idx: i for i, idx in enumerate(raw_indices)}
@@ -122,7 +122,7 @@ class StepChatJsonDataset(torch.utils.data.Dataset):
 
         with smart_open(f_path, "rb") as f:
             idx = -1
-            for item in ijson.items(f, "item", use_float=True):
+            for item in ijson.items(f, "conversations", use_float=True):
                 idx += 1
                 if 0.0 < sample_rate < 1.0 and idx not in raw_indices:
                     continue


### PR DESCRIPTION
- Constraint `uv` version >=0.8.4 for the `extra-build-dependencies` feature, see https://github.com/astral-sh/uv/pull/14735
- Add explanation for `DataRecipe.epochs` following Megatron-LM parameter semantics
- Fix dataset keywords #23 