### PR TITLE
feat(base_exp): prefer CUDA_VISIBLE_DEVICES settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -209,3 +209,6 @@ cython_debug/
 marimo/_static/
 marimo/_lsp/
 __marimo__/
+
+# Local training log
+tensorboard_logs/

--- a/steptronoss/exp/base_exp.py
+++ b/steptronoss/exp/base_exp.py
@@ -504,7 +504,17 @@ class BaseExp(Config):
         return writer
 
     def sanity_check(self):
-        expected_world_size = self.resource_cfg.replica * max(self.resource_cfg.gpu, 1)
+        # Determine actual available GPUs considering CUDA_VISIBLE_DEVICES
+        cuda_visible = os.getenv("CUDA_VISIBLE_DEVICES")
+        if cuda_visible is not None:
+            actual_gpus = len(cuda_visible.split(","))
+            logger.warning(
+                f"CUDA_VISIBLE_DEVICES is set to '{cuda_visible}', "
+                f"using {actual_gpus} GPU(s) instead of resource_cfg.gpu={self.resource_cfg.gpu}"
+            )
+        else:
+            actual_gpus = self.resource_cfg.gpu
+        expected_world_size = self.resource_cfg.replica * max(actual_gpus, 1)
         os.environ["WORLD_SIZE"] = os.environ.get(
             "WORLD_SIZE", str(expected_world_size)
         )  # for workspace check, fake the expected world_size


### PR DESCRIPTION
- 单机情况下优先 `export CUDA_VISIBLE_DEVICES` 决定几张卡。例如：
  - 服务器是好几个人共享，别人占了 0,3卡；日常使用需要指定 1,2 号卡。
  - 机器是异构的，PCIe 插了不同类型的卡
- 训完本地有个 tensorboard_logs， ignore 一下

提交多机任务一般不配置 CUDA_VISIBLE_DEVICES，没影响。