### PR TITLE
fix: Add synchronization for CUDA to CPU data copy

### DIFF
--- a/steptronoss/checkpointing/reshape_ops.py
+++ b/steptronoss/checkpointing/reshape_ops.py
@@ -9,7 +9,7 @@ from einops import rearrange
 from loguru import logger
 
 from steptronoss.core.parallel_state import PM
-from steptronoss.utils.dist_utils import all_gather_object
+from steptronoss.utils.dist_utils import all_gather_dict
 from steptronoss.utils.weight_loader import HFWeights, translate
 
 UnifiedTensorDict = dict[Any, torch.Tensor]
@@ -78,7 +78,7 @@ class Sequential(ReshapeOp):
 
 
 def _gather_reshape_piece(piece: dict, group):
-    return all_gather_object(piece, group=group)
+    return all_gather_dict(piece, group=group)
 
 
 class KeepThisTP(ReshapeOp):

--- a/steptronoss/utils/dist_utils.py
+++ b/steptronoss/utils/dist_utils.py
@@ -414,6 +414,9 @@ def tensor_to_dict(flat_byte_tensor_on_comm_device: torch.Tensor, keep_on_comm_d
                 # 否则，如果相同，则是一次设备内拷贝
                 # :target_uint8_view.numel()确保只复制所需字节数
                 source_bytes_for_copy = current_tensor_bytes_on_comm_device_view.to(target_device, non_blocking=True)
+                # cuda -> cpu is not safe according to https://docs.pytorch.org/tutorials/intermediate/pinmem_nonblock.html#other-copy-directions-gpu-cpu-cpu-mps
+                if target_device == torch.device("cpu"):
+                    torch.cuda.synchronize()
                 target_uint8_view.copy_(source_bytes_for_copy[: target_uint8_view.numel()])
                 del source_bytes_for_copy  # 如果发生了拷贝，释放这个中间拷贝
 


### PR DESCRIPTION
  Synchronize before consuming CUDA->CPU copies in `tensor_to_dict`.

  `tensor_to_dict` reconstructs tensors from a byte buffer on the comm device (comm_device is always cuda when available). When
  `target_device` is CPU, [dist_utils.py:416](https://github.com/stepfun-ai/SteptronOss/blob/798c93df4f28b7bc30c315b22773cf39922bbae3/steptronoss/utils/dist_utils.py#L416) issues a CUDA->CPU copy with `non_blocking=True`, and the next step immediately consumes the CPU result via `copy_()`.

https://github.com/stepfun-ai/SteptronOss/blob/798c93df4f28b7bc30c315b22773cf39922bbae3/steptronoss/utils/dist_utils.py#L416-L417

  PyTorch documents that `non_blocking=True` is only safe without explicit
  synchronization for CPU->CUDA transfers from pageable memory. For other
  directions, including CUDA->CPU, the caller must synchronize before accessing the
  copied data:
  https://docs.pytorch.org/tutorials/intermediate/pinmem_nonblock.html#other-copy-directions-gpu-cpu-cpu-mps

  This change adds the missing synchronization before the CPU buffer is read, so
  CPU tensor reconstruction does not observe incomplete device-to-host copies.