### PR TITLE
Fix parse_args split crash and add NaN guard to get_normalizer

### DIFF
--- a/steptronoss/utils/arguments.py
+++ b/steptronoss/utils/arguments.py
@@ -18,7 +18,7 @@ def parse_args():
     for o in args.opts:
         if "=" not in o:
             continue
-        key, value = o.split("=")
+        key, value = o.split("=", 1)
         try:
             value = ast.literal_eval(value)
         except:

--- a/steptronoss/utils/utils.py
+++ b/steptronoss/utils/utils.py
@@ -472,6 +472,8 @@ def get_normalizer(x: torch.Tensor):
     torch.distributed.all_reduce(v, group=PM.group_of("DP"))
     v /= n
     s = torch.sqrt(v)
+    if not (torch.isfinite(m) and torch.isfinite(s)):
+        raise ValueError(f"get_normalizer: non-finite result (mean={m}, std={s}). Input may contain NaN/inf.")
     return m, s
 
 

--- a/tests/test_arguments.py
+++ b/tests/test_arguments.py
@@ -1,0 +1,52 @@
+import sys
+
+import pytest
+
+pytestmark = pytest.mark.cpu
+
+
+@pytest.fixture(autouse=True)
+def _clear_argv(monkeypatch):
+    monkeypatch.setattr(sys, "argv", ["prog"])
+
+
+def _parse(opts):
+    sys.argv = ["prog"] + opts
+    from steptronoss.utils.arguments import parse_args
+
+    return parse_args()
+
+
+def test_normal_key_value():
+    result = _parse(["lr=0.001"])
+    assert result == {"lr": 0.001}
+
+
+def test_split_with_equals_in_value():
+    result = _parse(["load_path=s3://bucket/path?key=val"])
+    assert result == {"load_path": "s3://bucket/path?key=val"}
+
+
+def test_multiple_equals_in_value():
+    result = _parse(["envs=A=1,B=2"])
+    assert result == {"envs": "A=1,B=2"}
+
+
+def test_integer_and_bool_literals():
+    result = _parse(["train_iters=100", "flag=True"])
+    assert result == {"train_iters": 100, "flag": True}
+
+
+def test_false_string_stays_as_string():
+    result = _parse(["flag=false"])
+    assert result["flag"] == "false"
+
+
+def test_none_string_stays_as_string():
+    result = _parse(["val=null"])
+    assert result["val"] == "null"
+
+
+def test_opts_without_equals_are_skipped():
+    result = _parse(["no_equals_token", "lr=0.1"])
+    assert result == {"lr": 0.1}

--- a/tests/test_get_normalizer.py
+++ b/tests/test_get_normalizer.py
@@ -1,0 +1,51 @@
+from unittest.mock import MagicMock
+
+import pytest
+import torch
+
+pytestmark = pytest.mark.cpu
+
+
+@pytest.fixture(autouse=True)
+def _mock_distributed(monkeypatch):
+    monkeypatch.setattr(torch.distributed, "all_reduce", lambda t, group=None: None)
+    mock_pm = MagicMock()
+    mock_pm.group_of.return_value = None
+    import steptronoss.utils.utils as utils_mod
+
+    monkeypatch.setattr(utils_mod, "PM", mock_pm)
+
+
+def test_normal_input():
+    from steptronoss.utils.utils import get_normalizer
+
+    x = torch.tensor([1.0, 2.0, 3.0, 4.0, 5.0])
+    mean, std = get_normalizer(x)
+    assert torch.isfinite(mean)
+    assert torch.isfinite(std)
+    assert torch.isclose(mean, torch.tensor(3.0))
+
+
+def test_nan_input_raises():
+    from steptronoss.utils.utils import get_normalizer
+
+    x = torch.tensor([1.0, float("nan"), 3.0])
+    with pytest.raises(ValueError, match="non-finite"):
+        get_normalizer(x)
+
+
+def test_inf_input_raises():
+    from steptronoss.utils.utils import get_normalizer
+
+    x = torch.tensor([1.0, float("inf"), 3.0])
+    with pytest.raises(ValueError, match="non-finite"):
+        get_normalizer(x)
+
+
+def test_constant_input():
+    from steptronoss.utils.utils import get_normalizer
+
+    x = torch.tensor([5.0, 5.0, 5.0])
+    mean, std = get_normalizer(x)
+    assert torch.isclose(mean, torch.tensor(5.0))
+    assert torch.isclose(std, torch.tensor(0.0))


### PR DESCRIPTION
## Summary
- **parse_args**: `o.split("=")` splits on every `=` character. Config values containing `=` (e.g. `load_path=s3://bucket/path?key=val`) produce more than two parts, causing `ValueError: too many values to unpack`. Fixed by using `o.split("=", 1)`.
- **get_normalizer**: When any advantage element is NaN/inf, `mean` and `std` both become NaN. The downstream `std.clip_(0.01)` does not help because `clamp(NaN)` returns NaN per IEEE 754. All advantages silently become NaN, corrupting the training step. Added a `ValueError` check after computing mean and std.

## Test plan
- [x] `tests/test_arguments.py` — 7 tests covering: normal key=value, values with `=`, Python literals, `"false"`/`"null"` edge cases
- [x] `tests/test_get_normalizer.py` — 4 tests covering: normal input, NaN input, inf input, constant input (std=0)
- [x] `pytest tests/test_arguments.py tests/test_get_normalizer.py -v` — all 11 tests pass
- [x] `ruff check` and `ruff format` pass on all changed files
- [x] Existing tests unaffected: `pytest tests/exp/test_base_exp.py -v` passes